### PR TITLE
Add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ To get started with local development, follow these steps:
 
 5. Open [http://localhost:3000](http://localhost:3000) in your browser to see the app.
 
+## Troubleshooting
+
+### `npm install` fails or hangs
+
+If dependency installation fails, your environment may not have internet access to reach the npm registry. Ensure your development environment can access `registry.npmjs.org` or configure an offline mirror with all required packages. Without network access or preinstalled dependencies, the project won't build or run locally.
+
 ## Deployment
 
 Wayra is live on Vercel. Check it out [here](https://your-vercel-url.vercel.app).


### PR DESCRIPTION
## Summary
- document troubleshooting steps for failed dependency installation

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859b3625f9c8326809e685a073a45be