### PR TITLE
Add mock hotel demo with search filter

### DIFF
--- a/HotelSearchPage.tsx
+++ b/HotelSearchPage.tsx
@@ -1,6 +1,6 @@
-import mockHotels from '@/data/mockHotels.json';
+import mockHotels from '@/data/mock-hotels';
 import MapComponent from '@/components/MapComponent';
-import { HotelCard, HotelProps } from '@/components/hotel-card';
+import { HotelCard, HotelProps } from '@/components/hotels/hotel-card';
 
 export default function HotelSearchPage() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { LayoutShell } from "@/components/layout/layout-shell"
 import { SearchForm } from "@/components/search/search-form"
 import { ResultsWrapper } from "@/components/hotels/results-wrapper"
 import type { HotelProps } from "@/components/hotels/hotel-card"
+import mockHotels from "@/data/mock-hotels"
 
 export default function Wayra() {
   const [query, setQuery] = useState("")
@@ -14,110 +15,19 @@ export default function Wayra() {
   const [hotels, setHotels] = useState<HotelProps[]>([])
 
   const handleSearch = async (searchQuery: string) => {
-    // Don't re-search if the query is the same
     if (searchQuery === query && showResults) return
 
     setQuery(searchQuery)
     setIsLoading(true)
 
-    // Log search for analytics
-    console.log("Processing search:", searchQuery)
-
-    // Simulate API call to get hotel recommendations
     setTimeout(() => {
-      const results = getHotelRecommendations(searchQuery)
-      console.log("Found matches:", results.length)
-
+      const results = mockHotels.filter((h) =>
+        h.city.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+      setHotels(results)
       setIsLoading(false)
       setShowResults(true)
-      setHotels(results)
-    }, 1800)
-  }
-
-  const getHotelRecommendations = (input: string): HotelProps[] => {
-    // Simple logic to return different hotels based on the input
-    if (input.toLowerCase().includes("chicago")) {
-      return [
-        {
-          id: "1",
-          name: "The Langham, Chicago",
-          price: "$399",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Langham",
-          reason: "Luxury riverfront location with spacious rooms. Great for business travelers.",
-        },
-        {
-          id: "2",
-          name: "Chicago Athletic Association",
-          price: "$329",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Hyatt",
-          reason: "Historic property across from Millennium Park with unique architecture.",
-        },
-        {
-          id: "3",
-          name: "The Peninsula Chicago",
-          price: "$459",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Peninsula",
-          reason: "Five-star luxury on the Magnificent Mile with exceptional service.",
-        },
-      ]
-    } else if (input.toLowerCase().includes("new york") || input.toLowerCase().includes("nyc")) {
-      return [
-        {
-          id: "4",
-          name: "The Beekman",
-          price: "$389",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Thompson",
-          reason: "Historic downtown property with unique architecture and excellent dining.",
-        },
-        {
-          id: "5",
-          name: "1 Hotel Central Park",
-          price: "$429",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "1 Hotels",
-          reason: "Eco-friendly hotel near Central Park with natural design elements.",
-        },
-        {
-          id: "6",
-          name: "The Ritz-Carlton New York",
-          price: "$549",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Marriott",
-          reason: "Luxury hotel in Midtown with exceptional service and amenities.",
-        },
-      ]
-    } else {
-      return [
-        {
-          id: "7",
-          name: "The Ritz-Carlton",
-          price: "$429",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Marriott",
-          reason: "Exceptional service with premium amenities and central location.",
-        },
-        {
-          id: "8",
-          name: "Waldorf Astoria",
-          price: "$389",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Hilton",
-          reason: "Elegant luxury hotel with spacious rooms and excellent dining options.",
-        },
-        {
-          id: "9",
-          name: "Park Hyatt",
-          price: "$359",
-          image: "/placeholder.svg?height=300&width=500",
-          brand: "Hyatt",
-          reason: "Refined luxury with contemporary design and attentive service.",
-        },
-      ]
-    }
+    }, 800)
   }
 
   return (

--- a/components/hotels/hotel-card.tsx
+++ b/components/hotels/hotel-card.tsx
@@ -4,15 +4,17 @@ import Image from "next/image"
 import { motion } from "framer-motion"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { HotelBadge } from "@/components/hotels/hotel-badge"
+import { Star } from "lucide-react"
 
 export interface HotelProps {
   id: string
   name: string
-  price: string
+  city: string
+  location: string
+  rating: number
+  price: number
+  description: string
   image: string
-  brand: string
-  reason: string
 }
 
 interface HotelCardProps {
@@ -29,38 +31,29 @@ export function HotelCard({ hotel, index }: HotelCardProps) {
       whileHover={{ y: -4 }}
       className="group"
     >
-      <Card className="rounded-none border border-transparent hover:border-black/10 shadow-none overflow-hidden h-full flex flex-col transition-all duration-300">
+      <Card className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-all duration-300 h-full flex flex-col">
         <div className="relative aspect-[4/3] overflow-hidden">
           <Image
             src={hotel.image || "/placeholder.svg"}
             alt={hotel.name}
             fill
-            className="object-cover grayscale hover:grayscale-0 transition-all duration-500"
+            className="object-cover"
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             priority={index < 2}
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
         </div>
-        <CardContent className="px-0 pt-6 pb-4 flex-grow">
-          <div className="flex justify-between items-start mb-1">
-            <h3 className="font-medium text-lg md:text-xl">{hotel.name}</h3>
-            <HotelBadge brand={hotel.brand} />
-          </div>
-          <div className="flex flex-col md:flex-row md:justify-between md:items-center mb-4 gap-2">
-            <p className="text-black/60 text-sm">{hotel.reason}</p>
-            <p className="font-light whitespace-nowrap">
-              {hotel.price}
-              <span className="text-xs text-black/60">/night</span>
-            </p>
-          </div>
+        <CardContent className="p-4 flex-grow space-y-2">
+          <h3 className="font-medium text-lg md:text-xl">{hotel.name}</h3>
+          <p className="text-sm text-black/60">{hotel.location}, {hotel.city}</p>
+          <p className="text-sm text-black/80">{hotel.description}</p>
         </CardContent>
-        <CardFooter className="px-0 pt-0 mt-auto">
-          <Button
-            variant="outline"
-            className="w-full h-11 rounded-full border-black/20 hover:border-black hover:bg-white text-black transition-all duration-200 transform active:scale-[0.98]"
-          >
-            Book this hotel
-          </Button>
+        <CardFooter className="px-4 pb-4 pt-0 mt-auto flex items-center justify-between">
+          <div className="flex items-center gap-1 text-sm">
+            <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
+            <span>{hotel.rating}</span>
+          </div>
+          <p className="font-semibold">€{hotel.price}</p>
+          <Button size="sm" className="ml-auto rounded-full">Book</Button>
         </CardFooter>
       </Card>
     </motion.div>

--- a/components/hotels/results-wrapper.tsx
+++ b/components/hotels/results-wrapper.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { HotelCard, type HotelProps } from "@/components/hotels/hotel-card"
 import { HotelSkeleton } from "@/components/hotels/hotel-skeleton"
+import { Input } from "@/components/ui/input"
 
 interface ResultsWrapperProps {
   hotels: HotelProps[]
@@ -11,17 +13,32 @@ interface ResultsWrapperProps {
 }
 
 export function ResultsWrapper({ hotels, isLoading, showResults }: ResultsWrapperProps) {
+  const [filter, setFilter] = useState("")
+
   if (!showResults && !isLoading) return null
+
+  const filteredHotels = hotels.filter((h) =>
+    h.city.toLowerCase().includes(filter.toLowerCase())
+  )
 
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-12 md:mt-16" layout>
+      <div className="mb-6 max-w-sm">
+        <Input
+          placeholder="Filter by city"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+      </div>
       <AnimatePresence>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 md:gap-12">
           {isLoading
-            ? // Show skeletons while loading
-              Array.from({ length: 3 }).map((_, index) => <HotelSkeleton key={`skeleton-${index}`} />)
-            : // Show actual hotel results
-              hotels.map((hotel, index) => <HotelCard key={hotel.id} hotel={hotel} index={index} />)}
+            ? Array.from({ length: 3 }).map((_, index) => (
+                <HotelSkeleton key={`skeleton-${index}`} />
+              ))
+            : filteredHotels.map((hotel, index) => (
+                <HotelCard key={hotel.id} hotel={hotel} index={index} />
+              ))}
         </div>
       </AnimatePresence>
     </motion.div>

--- a/data/mock-hotels.ts
+++ b/data/mock-hotels.ts
@@ -1,0 +1,75 @@
+export interface MockHotel {
+  id: string;
+  name: string;
+  city: string;
+  location: string;
+  rating: number;
+  price: number;
+  description: string;
+  image: string;
+}
+
+export const mockHotels: MockHotel[] = [
+  {
+    id: 'bcn1',
+    name: 'Barcelona Center Hotel',
+    city: 'Barcelona',
+    location: 'Eixample',
+    rating: 4.6,
+    price: 180,
+    description: 'Modern rooms in the heart of Barcelona with easy access to public transport.',
+    image: 'https://source.unsplash.com/featured/?hotel,barcelona',
+  },
+  {
+    id: 'bcn2',
+    name: 'Sea View Barcelona',
+    city: 'Barcelona',
+    location: 'Barceloneta Beach',
+    rating: 4.4,
+    price: 210,
+    description: 'Beachfront property with stunning Mediterranean views and great nightlife nearby.',
+    image: 'https://source.unsplash.com/featured/?hotel,barcelona',
+  },
+  {
+    id: 'mad1',
+    name: 'Madrid Central Hotel',
+    city: 'Madrid',
+    location: 'Gran Vía',
+    rating: 4.5,
+    price: 160,
+    description: 'Elegant hotel steps from shops and theaters in bustling Gran Vía.',
+    image: 'https://source.unsplash.com/featured/?hotel,madrid',
+  },
+  {
+    id: 'mad2',
+    name: 'Royal Madrid Palace',
+    city: 'Madrid',
+    location: 'Centro',
+    rating: 4.7,
+    price: 220,
+    description: 'Luxury accommodations with classic decor near the Royal Palace.',
+    image: 'https://source.unsplash.com/featured/?hotel,madrid',
+  },
+  {
+    id: 'val1',
+    name: 'Valencia Sunset Resort',
+    city: 'Valencia',
+    location: 'City of Arts and Sciences',
+    rating: 4.8,
+    price: 200,
+    description: 'Resort-style stay with pool and spa next to Valencia\'s famous attractions.',
+    image: 'https://source.unsplash.com/featured/?hotel,valencia',
+  },
+  {
+    id: 'val2',
+    name: 'Old Town Valencia Inn',
+    city: 'Valencia',
+    location: 'Ciutat Vella',
+    rating: 4.3,
+    price: 130,
+    description: 'Charming boutique hotel tucked away in Valencia\'s historic center.',
+    image: 'https://source.unsplash.com/featured/?hotel,valencia',
+  },
+];
+
+export default mockHotels;

--- a/wayra.tsx
+++ b/wayra.tsx
@@ -15,8 +15,8 @@ import { Calendar } from "@/components/ui/calendar"
 import { Badge } from "@/components/ui/badge"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import mockHotels from '../mockHotels.json'
-import { HotelCard, HotelProps } from '@/components/hotel-card'
+import mockHotels from '@/data/mock-hotels'
+import { HotelCard, HotelProps } from '@/components/hotels/hotel-card'
 
 export default function Wayra() {
   const [dateRange, setDateRange] = useState<{ from: Date | undefined; to: Date | undefined }>({


### PR DESCRIPTION
## Summary
- create `mock-hotels.ts` with listings for Barcelona, Madrid and Valencia
- modernize hotel card component to show description, rating and price
- allow live filtering by city in `ResultsWrapper`
- wire new mock data into the homepage and other demo pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b46a3738832682b0801aadd0237d