### PR TITLE
Fix mockHotels import path

### DIFF
--- a/HotelSearchPage.tsx
+++ b/HotelSearchPage.tsx
@@ -1,4 +1,4 @@
-import mockHotels from '@/data/mockHotels.json';
+import mockHotels from '@/mockHotels.json';
 import MapComponent from '@/components/MapComponent';
 import { HotelCard, HotelProps } from '@/components/hotel-card';
 


### PR DESCRIPTION
## Summary
- fix wrong path for mockHotels data

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859b05b5fe48326bf3ab908adb70b44