### PR TITLE
Fix data and layout issues; add utility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If dependency installation fails, your environment may not have internet access 
 
 ## Deployment
 
-Wayra is live on Vercel. Check it out [here](https://your-vercel-url.vercel.app).
+Wayra is live on Vercel. Check it out at our [demo site](https://your-vercel-url.vercel.app).
 
 ## Tech Stack
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,3 @@ export default function RootLayout({
     </html>
   )
 }
-
-
-import './globals.css'

--- a/data/mock-hotels.ts
+++ b/data/mock-hotels.ts
@@ -7,6 +7,8 @@ export interface MockHotel {
   price: number;
   description: string;
   image: string;
+  latitude: number;
+  longitude: number;
 }
 
 export const mockHotels: MockHotel[] = [
@@ -19,6 +21,8 @@ export const mockHotels: MockHotel[] = [
     price: 180,
     description: 'Modern rooms in the heart of Barcelona with easy access to public transport.',
     image: 'https://source.unsplash.com/featured/?hotel,barcelona',
+    latitude: 41.389,
+    longitude: 2.1619,
   },
   {
     id: 'bcn2',
@@ -29,6 +33,8 @@ export const mockHotels: MockHotel[] = [
     price: 210,
     description: 'Beachfront property with stunning Mediterranean views and great nightlife nearby.',
     image: 'https://source.unsplash.com/featured/?hotel,barcelona',
+    latitude: 41.381,
+    longitude: 2.189,
   },
   {
     id: 'mad1',
@@ -39,6 +45,8 @@ export const mockHotels: MockHotel[] = [
     price: 160,
     description: 'Elegant hotel steps from shops and theaters in bustling Gran Vía.',
     image: 'https://source.unsplash.com/featured/?hotel,madrid',
+    latitude: 40.4203,
+    longitude: -3.7058,
   },
   {
     id: 'mad2',
@@ -49,6 +57,8 @@ export const mockHotels: MockHotel[] = [
     price: 220,
     description: 'Luxury accommodations with classic decor near the Royal Palace.',
     image: 'https://source.unsplash.com/featured/?hotel,madrid',
+    latitude: 40.417,
+    longitude: -3.716,
   },
   {
     id: 'val1',
@@ -59,6 +69,8 @@ export const mockHotels: MockHotel[] = [
     price: 200,
     description: 'Resort-style stay with pool and spa next to Valencia\'s famous attractions.',
     image: 'https://source.unsplash.com/featured/?hotel,valencia',
+    latitude: 39.455,
+    longitude: -0.355,
   },
   {
     id: 'val2',
@@ -69,6 +81,8 @@ export const mockHotels: MockHotel[] = [
     price: 130,
     description: 'Charming boutique hotel tucked away in Valencia\'s historic center.',
     image: 'https://source.unsplash.com/featured/?hotel,valencia',
+    latitude: 39.474,
+    longitude: -0.378,
   },
 ];
 

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -93,8 +93,8 @@ export const reducer = (state: State, action: Action): State => {
     case "DISMISS_TOAST": {
       const { toastId } = action
 
-      // ! Side effects ! - This could be extracted into a dismissToast() action,
-      // but I'll keep it here for simplicity
+      // Trigger side effects here. We could move this logic into a dedicated
+      // dismissToast() helper, but it is kept inline for simplicity.
       if (toastId) {
         addToRemoveQueue(toastId)
       } else {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "latest",
@@ -68,6 +69,7 @@
     "@types/react-dom": "^19",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from '../lib/utils'
+
+describe('cn utility', () => {
+  it('merges class names and ignores falsy values', () => {
+    const result = cn('p-2', false && 'hidden', 'text-center')
+    expect(result).toBe('p-2 text-center')
+  })
+
+  it('deduplicates tailwind classes', () => {
+    const result = cn('p-2', 'p-2', 'text-sm')
+    expect(result).toBe('p-2 text-sm')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- remove stray import from layout
- add coordinates to mock hotel data
- clarify toast side-effect comment
- tweak README deployment link wording
- add vitest config and utility test

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b6f078788326974f44fca9bd5202