### PR TITLE
Fix trimming for hotel search

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,14 +15,15 @@ export default function Wayra() {
   const [hotels, setHotels] = useState<HotelProps[]>([])
 
   const handleSearch = async (searchQuery: string) => {
-    if (searchQuery === query && showResults) return
+    const trimmed = searchQuery.trim()
+    if (trimmed === query && showResults) return
 
-    setQuery(searchQuery)
+    setQuery(trimmed)
     setIsLoading(true)
 
     setTimeout(() => {
       const results = mockHotels.filter((h) =>
-        h.city.toLowerCase().includes(searchQuery.toLowerCase())
+        h.city.toLowerCase().includes(trimmed.toLowerCase())
       )
       setHotels(results)
       setIsLoading(false)

--- a/components/hotels/results-wrapper.tsx
+++ b/components/hotels/results-wrapper.tsx
@@ -17,8 +17,9 @@ export function ResultsWrapper({ hotels, isLoading, showResults }: ResultsWrappe
 
   if (!showResults && !isLoading) return null
 
+  const normalized = filter.trim().toLowerCase()
   const filteredHotels = hotels.filter((h) =>
-    h.city.toLowerCase().includes(filter.toLowerCase())
+    h.city.toLowerCase().includes(normalized)
   )
 
   return (

--- a/components/search/search-form.tsx
+++ b/components/search/search-form.tsx
@@ -46,7 +46,7 @@ export function SearchForm({ onSearch, isLoading, showResults, initialQuery = ""
     if (!isSubmitEnabled || isLoading) return
 
     // Call the debounced search function
-    debouncedSearch(query)
+    debouncedSearch(query.trim())
   }
 
   return (


### PR DESCRIPTION
## Summary
- trim user input before searching hotel data
- trim filter text

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ba17803c83268a9d658b191a2156