### PR TITLE
Fix toast duration

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,8 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// How long a toast should remain visible before being removed (in ms)
+const TOAST_REMOVE_DELAY = 10000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten toast removal delay so toasts auto-dismiss sooner

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cd09430c8326ac6d8bf2c4844423