### PR TITLE
Fix hotel results list

### DIFF
--- a/components/hotels/results-wrapper.tsx
+++ b/components/hotels/results-wrapper.tsx
@@ -22,6 +22,9 @@ export function ResultsWrapper({ hotels, isLoading, showResults }: ResultsWrappe
     h.city.toLowerCase().includes(normalized)
   )
 
+  console.log("Query:", filter)
+  console.log("Filtered results:", filteredHotels)
+
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-12 md:mt-16" layout>
       <div className="mb-6 max-w-sm">
@@ -37,9 +40,15 @@ export function ResultsWrapper({ hotels, isLoading, showResults }: ResultsWrappe
             ? Array.from({ length: 3 }).map((_, index) => (
                 <HotelSkeleton key={`skeleton-${index}`} />
               ))
-            : filteredHotels.map((hotel, index) => (
-                <HotelCard key={hotel.id} hotel={hotel} index={index} />
-              ))}
+            : filteredHotels.length > 0 ? (
+                filteredHotels.map((hotel, index) => (
+                  <HotelCard key={hotel.id} hotel={hotel} index={index} />
+                ))
+              ) : (
+                <p className="col-span-full text-center text-sm text-black/60">
+                  No hotels found for your search.
+                </p>
+              )}
         </div>
       </AnimatePresence>
     </motion.div>

--- a/components/search/search-form.tsx
+++ b/components/search/search-form.tsx
@@ -8,7 +8,6 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { RotatingPlaceholder } from "@/components/search/rotating-placeholder"
 import { TermsCheckbox } from "@/components/search/terms-checkbox"
-import { useDebounce } from "@/hooks/use-debounce"
 
 interface SearchFormProps {
   onSearch: (query: string) => void
@@ -22,7 +21,6 @@ export function SearchForm({ onSearch, isLoading, showResults, initialQuery = ""
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [isSubmitEnabled, setIsSubmitEnabled] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
-  const debouncedSearch = useDebounce(onSearch, 2000)
 
   // Validate form and enable/disable submit
   useEffect(() => {
@@ -45,8 +43,7 @@ export function SearchForm({ onSearch, isLoading, showResults, initialQuery = ""
     e.preventDefault()
     if (!isSubmitEnabled || isLoading) return
 
-    // Call the debounced search function
-    debouncedSearch(query.trim())
+    onSearch(query.trim())
   }
 
   return (


### PR DESCRIPTION
## Summary
- ensure search results are shown without debouncing
- log search query and filtered results for debugging
- display fallback text when no hotel matches the filter

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bffa3c948326a179647430dd3f71