### PR TITLE
Fix hotel results list

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,8 @@ export default function Wayra() {
   const [isLoading, setIsLoading] = useState(false)
   const [hotels, setHotels] = useState<HotelProps[]>([])
 
+  const knownCities = ["Barcelona", "Madrid", "London", "Valencia"]
+
   const handleSearch = async (searchQuery: string) => {
     const trimmed = searchQuery.trim()
     if (trimmed === query && showResults) return
@@ -22,9 +24,22 @@ export default function Wayra() {
     setIsLoading(true)
 
     setTimeout(() => {
-      const results = mockHotels.filter((h) =>
-        h.city.toLowerCase().includes(trimmed.toLowerCase())
+      const detected = knownCities.find((city) =>
+        trimmed.toLowerCase().includes(city.toLowerCase())
       )
+
+      console.log("Query:", trimmed)
+      console.log("Detected city:", detected)
+
+      let results: HotelProps[] = []
+      if (detected) {
+        results = mockHotels.filter(
+          (hotel) => hotel.city.toLowerCase() === detected.toLowerCase()
+        )
+      }
+
+      console.log("Filtered results:", results)
+
       setHotels(results)
       setIsLoading(false)
       setShowResults(true)

--- a/components/hotels/results-wrapper.tsx
+++ b/components/hotels/results-wrapper.tsx
@@ -13,22 +13,25 @@ interface ResultsWrapperProps {
 }
 
 export function ResultsWrapper({ hotels, isLoading, showResults }: ResultsWrapperProps) {
-  const [filter, setFilter] = useState("")
+  const [query, setQuery] = useState("")
 
   if (!showResults && !isLoading) return null
 
-  const normalized = filter.trim().toLowerCase()
-  const filteredHotels = hotels.filter((h) =>
+  const normalized = query.trim().toLowerCase()
+  const filtered = hotels.filter((h) =>
     h.city.toLowerCase().includes(normalized)
   )
+
+  console.log("Query:", query)
+  console.log("Filtered results:", filtered)
 
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-12 md:mt-16" layout>
       <div className="mb-6 max-w-sm">
         <Input
           placeholder="Filter by city"
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
         />
       </div>
       <AnimatePresence>
@@ -37,9 +40,15 @@ export function ResultsWrapper({ hotels, isLoading, showResults }: ResultsWrappe
             ? Array.from({ length: 3 }).map((_, index) => (
                 <HotelSkeleton key={`skeleton-${index}`} />
               ))
-            : filteredHotels.map((hotel, index) => (
-                <HotelCard key={hotel.id} hotel={hotel} index={index} />
-              ))}
+            : filtered.length > 0 ? (
+                filtered.map((hotel, index) => (
+                  <HotelCard key={hotel.id} hotel={hotel} index={index} />
+                ))
+              ) : (
+                <p className="col-span-full text-center text-sm text-black/60">
+                  No hotels found for your search.
+                </p>
+              )}
         </div>
       </AnimatePresence>
     </motion.div>

--- a/components/search/search-form.tsx
+++ b/components/search/search-form.tsx
@@ -8,7 +8,6 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { RotatingPlaceholder } from "@/components/search/rotating-placeholder"
 import { TermsCheckbox } from "@/components/search/terms-checkbox"
-import { useDebounce } from "@/hooks/use-debounce"
 
 interface SearchFormProps {
   onSearch: (query: string) => void
@@ -22,7 +21,6 @@ export function SearchForm({ onSearch, isLoading, showResults, initialQuery = ""
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [isSubmitEnabled, setIsSubmitEnabled] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
-  const debouncedSearch = useDebounce(onSearch, 2000)
 
   // Validate form and enable/disable submit
   useEffect(() => {
@@ -45,8 +43,7 @@ export function SearchForm({ onSearch, isLoading, showResults, initialQuery = ""
     e.preventDefault()
     if (!isSubmitEnabled || isLoading) return
 
-    // Call the debounced search function
-    debouncedSearch(query.trim())
+    onSearch(query.trim())
   }
 
   return (


### PR DESCRIPTION
## Summary
- ensure search results are shown without debouncing
- log search query and filtered results for debugging
- display fallback text when no hotel matches the filter
- simplify filter variable names
- support natural language city detection when searching

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bffa3c948326a179647430dd3f71