### PR TITLE
Support natural language hotel search

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { SearchForm } from "@/components/search/search-form"
 import { ResultsWrapper } from "@/components/hotels/results-wrapper"
 import type { HotelProps } from "@/components/hotels/hotel-card"
 import mockHotels from "@/data/mock-hotels"
+import { detectCity } from "@/lib/utils"
 
 export default function Wayra() {
   const [query, setQuery] = useState("")
@@ -22,9 +23,16 @@ export default function Wayra() {
     setIsLoading(true)
 
     setTimeout(() => {
-      const results = mockHotels.filter((h) =>
-        h.city.toLowerCase().includes(trimmed.toLowerCase())
-      )
+      const detected = detectCity(trimmed)
+      const results = detected
+        ? mockHotels.filter(
+            (h) => h.city.toLowerCase() === detected.toLowerCase()
+          )
+        : []
+
+      console.log("Detected city:", detected)
+      console.log("Filtered results:", results)
+
       setHotels(results)
       setIsLoading(false)
       setShowResults(true)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,21 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// List of cities that Wayra currently recognizes
+export const knownCities = [
+  "Barcelona",
+  "Madrid",
+  "London",
+  "Valencia",
+]
+
+/**
+ * Detects the first known city found in the provided query string.
+ * Matching is case-insensitive.
+ */
+export function detectCity(query: string): string | undefined {
+  return knownCities.find((city) =>
+    query.toLowerCase().includes(city.toLowerCase())
+  )
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { cn } from '../lib/utils'
+import { cn, detectCity } from '../lib/utils'
 
 describe('cn utility', () => {
   it('merges class names and ignores falsy values', () => {
@@ -10,5 +10,22 @@ describe('cn utility', () => {
   it('deduplicates tailwind classes', () => {
     const result = cn('p-2', 'p-2', 'text-sm')
     expect(result).toBe('p-2 text-sm')
+  })
+})
+
+describe('detectCity utility', () => {
+  it('finds a city in a query string', () => {
+    const city = detectCity('Looking for hotels in Barcelona for tonight')
+    expect(city).toBe('Barcelona')
+  })
+
+  it('is case insensitive', () => {
+    const city = detectCity('madrid weekend trip')
+    expect(city).toBe('Madrid')
+  })
+
+  it('returns undefined when no city is found', () => {
+    const city = detectCity('some random place')
+    expect(city).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- add `detectCity` utility with list of `knownCities`
- use the city detection in the main search flow
- log the detected city and filtered results
- test the new utility functions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d217ff2c8326ab92dcfb540ccd56