### PR TITLE
Improve natural query parsing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { SearchForm } from "@/components/search/search-form"
 import { ResultsWrapper } from "@/components/hotels/results-wrapper"
 import type { HotelProps } from "@/components/hotels/hotel-card"
 import mockHotels from "@/data/mock-hotels"
-import { detectCity } from "@/lib/utils"
+import { parseSearchQuery } from "@/lib/utils"
 
 export default function Wayra() {
   const [query, setQuery] = useState("")
@@ -23,14 +23,17 @@ export default function Wayra() {
     setIsLoading(true)
 
     setTimeout(() => {
-      const detected = detectCity(trimmed)
-      const results = detected
+      const { city, maxPrice } = parseSearchQuery(trimmed)
+      const results = city
         ? mockHotels.filter(
-            (h) => h.city.toLowerCase() === detected.toLowerCase()
+            (h) =>
+              h.city.toLowerCase().includes(city.toLowerCase()) &&
+              (maxPrice ? h.price <= maxPrice : true)
           )
         : []
 
-      console.log("Detected city:", detected)
+      console.log("Detected city:", city)
+      console.log("Max price:", maxPrice)
       console.log("Filtered results:", results)
 
       setHotels(results)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,3 +22,17 @@ export function detectCity(query: string): string | undefined {
     query.toLowerCase().includes(city.toLowerCase())
   )
 }
+
+/**
+ * Parses a search query to extract a known city and optional maximum price.
+ */
+export function parseSearchQuery(query: string): {
+  city?: string
+  maxPrice?: number
+} {
+  const city = detectCity(query)
+  const match = query.match(/under\s*\$?(\d+)/i)
+  const maxPrice = match ? parseInt(match[1], 10) : undefined
+
+  return { city, maxPrice }
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { cn, detectCity } from '../lib/utils'
+import { cn, detectCity, parseSearchQuery } from '../lib/utils'
 
 describe('cn utility', () => {
   it('merges class names and ignores falsy values', () => {
@@ -27,5 +27,19 @@ describe('detectCity utility', () => {
   it('returns undefined when no city is found', () => {
     const city = detectCity('some random place')
     expect(city).toBeUndefined()
+  })
+})
+
+describe('parseSearchQuery utility', () => {
+  it('extracts city and price from query', () => {
+    const result = parseSearchQuery('London next week under $200')
+    expect(result.city).toBe('London')
+    expect(result.maxPrice).toBe(200)
+  })
+
+  it('handles missing price', () => {
+    const result = parseSearchQuery('Barcelona for two nights')
+    expect(result.city).toBe('Barcelona')
+    expect(result.maxPrice).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- extract city and price from search strings
- filter results using optional price cap
- test `parseSearchQuery` utility

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d34c90b08326ba0211dc93d53dd1