### PR TITLE
Fix broken hotel images

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,16 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'source.unsplash.com',
+      },
+    ],
   },
   experimental: {
     webpackBuildWorker: true,


### PR DESCRIPTION
## Summary
- add Unsplash domains to Next.js image config so hotel photos load

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d84f63b8c8326bd9f4537ce438129